### PR TITLE
fix: update handling of Apple Silicon version availability

### DIFF
--- a/internal/helper/versions.go
+++ b/internal/helper/versions.go
@@ -34,10 +34,11 @@ func GetAvailableVersions() ([]string, error) {
 			if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 				versionSlice := strings.Split(version, ".")
 				majInt, _ := strconv.Atoi(versionSlice[0])
+				minInt, _ := strconv.Atoi(versionSlice[1])
 				patchInt, _ := strconv.Atoi(versionSlice[2])
 
 				// Do not include pre-release versions or incompatible versions
-				if majInt >= 1 && patchInt >= 2 && !strings.Contains(version, "-") {
+				if (majInt >= 1 && minInt >= 1 || majInt >= 1 && minInt == 0 && patchInt >= 2) && !strings.Contains(version, "-") {
 					versions = append(versions, version)
 				}
 			} else {
@@ -58,18 +59,15 @@ func IsAvailableVersion(version string) error {
 	// Check that Apple Silicon users select a valid version (v1.0.2+).
 	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 		versionSlice := strings.Split(version, ".")
-
-		majInt, err := strconv.Atoi(versionSlice[0])
-		if err != nil {
+		if len(versionSlice) < 3 {
+			err = errors.New("invalid Terraform version, run `tfvm install --list` for a list of available versions")
 			return err
 		}
 
-		patchInt, err := strconv.Atoi(versionSlice[2])
-		if err != nil {
-			return err
-		}
-
-		if !(majInt >= 1 && patchInt >= 2) {
+		majInt, _ := strconv.Atoi(versionSlice[0])
+		minInt, _ := strconv.Atoi(versionSlice[1])
+		patchInt, _ := strconv.Atoi(versionSlice[2])
+		if !(majInt >= 1 && minInt >= 1 || majInt >= 1 && minInt == 0 && patchInt >= 2) {
 			err = errors.New("only Terraform v1.0.2+ is supported on Apple Silicon")
 			return err
 		}


### PR DESCRIPTION
# Pull Request

## Link any Issues related to this PR:
N/A
## What kind of change does this PR introduce?
Fix
## What is the current behavior?
Apple Silicon version handling broke any version with a patch version < 2.
## What is the new behavior?
Apple Silicon version handling behaves as expected (allowing any version >= 1.0.2).
Also updates error handling.
## Does this PR introduce a breaking change? If yes, what is the impact/migration path for consumers?
No
## How was this tested?

## Other Information (What are you unsure of? Anything else we should know?)
